### PR TITLE
Rebase to Godot 4.2

### DIFF
--- a/Scenes/Enemy/EnemyBase.tscn
+++ b/Scenes/Enemy/EnemyBase.tscn
@@ -92,15 +92,13 @@ _data = {
 "RESET": SubResource("3")
 }
 
-[node name="Enemy" type="CharacterBody2D" node_paths=PackedStringArray("aggro", "deaggro", "enemy_body", "telegraph", "main", "animation_player") groups=["minimap_objects"]]
+[node name="Enemy" type="CharacterBody2D" node_paths=PackedStringArray("aggro", "deaggro", "enemy_body", "animation_player") groups=["minimap_objects"]]
 collision_layer = 2
 collision_mask = 13
 script = ExtResource("1_3q22x")
 aggro = NodePath("VisionRange/AggroRange")
 deaggro = NodePath("VisionRange/DeaggroRange")
 enemy_body = NodePath(".")
-telegraph = NodePath("Sprites/TelegraphSprites/Eyes")
-main = NodePath("Sprites/HiddenSprites/Main")
 animation_player = NodePath("AnimationPlayer")
 move_options = [NodePath("Movement/Roam"), NodePath("Movement/Chase")]
 action_options = [NodePath("Actions/Basic Attack")]

--- a/project.godot
+++ b/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="SelenHorrorGungeon"
 run/main_scene="res://Scenes/Test Files/Test.tscn"
-config/features=PackedStringArray("4.1")
+config/features=PackedStringArray("4.2")
 run/max_fps=120
 config/icon="res://icon.png"
 


### PR DESCRIPTION
### What is the change?

Rebased the project to 4.2. Godot 4.2 is now stable, [which comes with a lot of behind the scenes stability and performance improvements and also improvements for tiles. ](https://godotengine.org/article/godot-4-2-arrives-in-style/)

- Tiles can be rotated.
- Stability enhancements, especially in changing scenes during _ready
- Navigation is improved for 2D games
- Animations improved
- Extension support improved

### What changes did you need to make?

None whatsoever. [We were not affected by these changes.](https://docs.godotengine.org/en/stable/tutorials/migrating/upgrading_to_godot_4.2.html) 

The AnimationMixer will complain if you mix update methods, that's it.

### Are there alternatives to your change?

None that will give the features 4.2 gives. Staying on 4.1 for the remainder of the project is also an option.

The cost of upgrading is minimal compared to the change to 4.1.