### PR TITLE
Added some Github Issue and PR templates based on TModLoader's

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,89 @@
+name: Bug Report
+description: Report a bug in the game
+labels: ["Type: Bug", "NEW ISSUE"]
+body:
+- type: markdown
+  attributes:
+    value: |
+      ## Is there an existing issue for this?
+      Please search using the search bar on the issues page to see if an issue already exists for the bug you encountered. If there is, please add to that issue instead of making a new issue. You can also react with 👍 to prioritize and issue.
+- type: dropdown
+  attributes:
+    label: Version
+    description: What version of Godot was this error encountered on?
+    multiple: false
+    options:
+      - Godot 4.2.X
+      - Godot 4.1.2
+      - Godot 4.0.X
+      - Godot 3.5.2
+      - Self-Compiled (please specify branch)
+      - Other (please specify elsewhere)
+  validations:
+    required: true
+- type: dropdown
+  attributes:
+    label: OS
+    description: What OS are you on?
+    multiple: false
+    options:
+      - Windows
+      - Mac
+      - Linux
+      - Android
+  validations:
+    required: true
+- type: dropdown
+  validations:
+    required: true
+- type: dropdown
+  attributes:
+    label: This bug affects
+    description: In order to help understand the issue, we would like to know if this is a player-facing bug, or a dev-facing bug
+    multiple: false
+    options:
+      - 'Dev capability as a Dev'
+      - 'Gameplay as a Player'
+  validations:
+    required: true        
+- type: textarea
+  attributes:
+    label: Description
+    id: description
+    description: |
+      Describe your issue(s) here. What is the issue?
+      Please keep this as concise as possible, preferably a single line describing the issue. 
+      For example: "When I press X button in menu Y, the component Z becomes unclickable"
+- type: textarea
+  attributes:
+    label: Log File
+    description: |
+      Have any interesting tidbits from the Godot console? See anything with breakpoints?
+- type: textarea
+  attributes:
+    label: Steps to reproduce
+    description: Please describe the steps to reproduce this issue.
+    placeholder: |
+      1. [First Step]
+      2. [Second Step]
+      3. [And so on...]
+- type: textarea
+  attributes:
+    label: Expected Behavior
+    description: |
+      What should be happening? If you don't know, leave what you think should happen
+- type: textarea
+  attributes:
+    label: Actual Behavior
+    description: |
+      What is actually happening?
+- type: textarea
+  attributes:
+    label: Reproduction frequency
+    description: |
+      How often are you reliably able to reproduce this issue?
+- type: textarea
+  attributes:
+    label: Additional Information
+    description: |
+       Any additional information, configuration, or data that might be necessary to reproduce the issue.

--- a/.github/ISSUE_TEMPLATE/feature_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/feature_proposal.yml
@@ -1,0 +1,43 @@
+name: Feature Proposal
+description: Propose a new feature/change for the game
+labels: ["Type: Change/Feature Request", "NEW ISSUE"] 
+body:
+- type: markdown
+  attributes:
+    value: |
+      ## Is there an existing suggestion for this?
+      Please search to see if an issue already exists for the feature you wish to propose.
+- type: dropdown
+  id: contribute
+  attributes:
+    label: Do you intend to personally contribute/program this feature?
+    description: If you feel confident that you can contribute this feature, feel free to work on it after getting some initial feedback. If you can't, don't worry, there are many people who can help and the suggestion is great by itself.
+    multiple: false
+    options:
+      - 'Yes'
+      - 'No'
+  validations:
+    required: true   
+- type: textarea
+  id: description
+  attributes:
+    label: Description
+    description: |
+      Describe your proposal. 
+    placeholder: |
+      A new scene called CoolScene could allow modders to...
+- type: textarea
+  id: why
+  attributes:
+    label: What does this proposal attempt to solve or improve?
+    description: |
+      Describe how your proposal is beneficial for the the game. Please list an example use case for the new feature.
+    placeholder: |
+      It is currently impossible to have the Player...
+      This new feature would allow us to implement...
+- type: textarea
+  id: alternatives
+  attributes:
+    label: Which (other) solutions should be considered?
+    description: |
+      Are there alternatives to your proposal? Please list them here. It is okay to leave this empty if none are applicable.

--- a/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
@@ -1,0 +1,6 @@
+### What is the bug?
+
+### How did you fix the bug?
+
+### Are there alternatives to your fix?
+

--- a/.github/PULL_REQUEST_TEMPLATE/new_feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/new_feature.md
@@ -1,0 +1,10 @@
+### What is the new feature?
+
+### Why should this be part of the game?
+
+### Are there alternative designs?
+
+### Sample usage for the new feature
+
+### Do your code changes include a demonstration available in a Test map?
+


### PR DESCRIPTION
### What is the new feature?

I'm adding templates so we can make creating PRs that are clean and informative easier.

### Why should this be part of the game?

It's actually part of the Github itself. These files do not touch the game at all.

### Are there alternative designs?

Making different templates, writing PRs in different formats.

### Sample usage for the new feature

This PR is structured like the template it would bring to the table.

### Do your code changes include a demonstration available in a Test map?

No. It is not applicable.